### PR TITLE
fix: flattedの脆弱性を修正

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,8 +698,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1714,10 +1714,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
## 更新されたパッケージ

- flatted: 3.3.3 → 3.4.2（パッチアップデート、transitive依存）

## 解消見込みのアラート（1件）

- [alert 36](https://github.com/ikemo3/google-search-datepicker-fix/security/dependabot/36): flatted high（修正版 3.4.2）

## リスク評価

パッチアップデート。direct dependencyではなくtransitive依存（eslint → file-entry-cache → flat-cache → flatted）のためアプリコードに影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)