### PR TITLE
chore: pnpm v11 への移行 (workspace config 追加)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   node-version: "24.16.0"
-  pnpm-version: "10.33.4"
+  pnpm-version: "11.2.2"
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "vitest": "^4.1.7",
     "zip-a-folder": "6.1.1"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.2.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Renovate PR #1604 (pnpm v10 → v11) を引き継ぎ、CI fail の原因だった pnpm-workspace.yaml の追加を実施
- pnpm v11 では build script を持つパッケージ (esbuild) の install に \`onlyBuiltDependencies\` での明示許可が必要、かつこの設定の読み取り元が \`package.json\` の \`pnpm.*\` から \`pnpm-workspace.yaml\` に移動した
- 本 PR で \`pnpm-workspace.yaml\` を新規作成して esbuild を許可

## Replaces

- #1604

## Test plan

- [ ] CI が green (pnpm install + build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)